### PR TITLE
Fix string `length` conflict with `requireAll`

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -86,6 +86,10 @@ class Generator
             throw new \InvalidArgumentException('Cannot generate random string with no character sets enabled!');
         }
 
+        if ($requireAll && count($chars) > $length) {
+            throw new \InvalidArgumentException('Length not enough to requireAll!');
+        }
+
         $string = '';
 
         if ($requireAll) {

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -160,6 +160,23 @@ class StringTest extends TestCase
         }
     }
 
+    public function testCantRequireAllWithoutEnoughLength()
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Length not enough to requireAll!');
+
+            Random::string(
+                $length = 2,
+                $lower = true,
+                $upper = true,
+                $numbers = false,
+                $symbols = true,
+                $requireAll = true
+            );
+        }
+    }
+
     public function testLetters()
     {
         for ($i = 0; $i < 100; $i++) {


### PR DESCRIPTION
Fixes #7

To fix the conflict between the `length` and `requireAll`, I make sure that the `length` is enough to require all the types of  input. If not it throws an error.

### Examples

```php
use Valorin\Random\Random;

$generator = Random::useLower(range('a', 'f'))
    ->useUpper(range('G', 'L'))
    ->useNumbers(range(2, 6))
    ->useSymbols(['!', '@', '#', '$', '%', '^', '&', '*', '(', ')']);

$string = $generator->string(
    $length = 2,
    $lower = true,
    $upper = false,
    $numbers = true,
    $symbols = true,
    $requireAll = true
);

var_dump($string);
```

`Fatal error: Uncaught InvalidArgumentException: Length not enough to requireAll!`

In this case it will throw an error because `length = 2` is not enough to require all the three (`lower`, `numbers` and `symbols`)


---------------------
But if we deactivate `numbers` so we can have only `2`, This will work and require both `lower` and `symbols`.
```php
use Valorin\Random\Random;

$generator = Random::useLower(range('a', 'f'))
    ->useUpper(range('G', 'L'))
    ->useNumbers(range(2, 6))
    ->useSymbols(['!', '@', '#', '$', '%', '^', '&', '*', '(', ')']);

$string = $generator->string(
    $length = 2,
    $lower = true,
    $upper = false,
    $numbers = false,
    $symbols = true,
    $requireAll = true
);

var_dump($string);
```

`string(2) "%b"`