### PR TITLE
Fix `pick($count)`

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -233,11 +233,11 @@ class Generator
             throw new \InvalidArgumentException('Can not pick less than one item.');
         }
 
-        if (!is_string($values) && !is_array($values) && ! $values instanceof Collection) {
+        if (! is_string($values) && ! is_array($values) && ! $values instanceof Collection) {
             throw new \InvalidArgumentException('$value must be a string, array, or \Illuminate\Support\Collection.');
         }
 
-        if (is_string($values) && $count > strlen($values) || !is_string($values) && $count > count($values)) {
+        if ((is_string($values) && $count > strlen($values)) || (! is_string($values) && $count > count($values))) {
             throw new \InvalidArgumentException('Can not pick more than existing elements.');
         }
 
@@ -247,10 +247,6 @@ class Generator
             return $values[0];
         }
 
-        if (is_array($values)) {
-            return array_slice($values, 0, $count);
-        }
-
         if (is_string($values)) {
             return substr($values, 0, $count);
         }
@@ -258,6 +254,8 @@ class Generator
         if ($values instanceof Collection) {
             return $values->slice(0, $count);
         }
+
+        return array_slice($values, 0, $count);
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -233,6 +233,14 @@ class Generator
             throw new \InvalidArgumentException('Can not pick less than one item.');
         }
 
+        if (!is_string($values) && !is_array($values) && ! $values instanceof Collection) {
+            throw new \InvalidArgumentException('$value must be a string, array, or \Illuminate\Support\Collection.');
+        }
+
+        if (is_string($values) && $count > strlen($values) || !is_string($values) && $count > count($values)) {
+            throw new \InvalidArgumentException('Can not pick more than existing elements.');
+        }
+
         $values = $this->shuffle($values);
 
         if ($count === 1) {
@@ -250,8 +258,6 @@ class Generator
         if ($values instanceof Collection) {
             return $values->slice(0, $count);
         }
-
-        throw new \InvalidArgumentException('$value must be a string, array, or \Illuminate\Support\Collection.');
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -229,6 +229,10 @@ class Generator
      */
     public function pick($values, int $count)
     {
+        if ($count < 1) {
+            throw new \InvalidArgumentException('Can not pick less than one item.');
+        }
+
         $values = $this->shuffle($values);
 
         if ($count === 1) {

--- a/tests/PickTest.php
+++ b/tests/PickTest.php
@@ -30,6 +30,16 @@ class PickTest extends TestCase
         }
     }
 
+    public function testCantPickMoreThanArrayElements()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick more than existing elements.');
+
+            Random::pick(range('a', 'z'), 27);
+        }
+    }
+
     public function testCantPickZeroElementFromString()
     {
         for ($i = 0; $i < 10; $i++) {
@@ -47,6 +57,16 @@ class PickTest extends TestCase
             $this->expectExceptionMessage('Can not pick less than one item.');
 
             Random::pick('abcdefghijklmnopqrstuvwxyz', -1);
+        }
+    }
+
+    public function testCantPickMoreThanStringElements()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick more than existing elements.');
+
+            Random::pick('abcdefghijklmnopqrstuvwxyz', 27);
         }
     }
 
@@ -69,6 +89,17 @@ class PickTest extends TestCase
 
             $collection = new Collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
             Random::pick($collection, -1);
+        }
+    }
+
+    public function testCantPickMoreThanCollectionElements()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick more than existing elements.');
+
+            $collection = new Collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
+            Random::pick($collection, 10);
         }
     }
 

--- a/tests/PickTest.php
+++ b/tests/PickTest.php
@@ -10,6 +10,68 @@ class PickTest extends TestCase
 {
     use Assertions;
 
+    public function testCantPickZeroElementFromArray()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick less than one item.');
+
+            Random::pick(range('a', 'z'), 0);
+        }
+    }
+
+    public function testCantPickLessThanZeroElementFromArray()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick less than one item.');
+
+            Random::pick(range('a', 'z'), -1);
+        }
+    }
+
+    public function testCantPickZeroElementFromString()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick less than one item.');
+
+            Random::pick('abcdefghijklmnopqrstuvwxyz', 0);
+        }
+    }
+
+    public function testCantPickLessThanZeroElementFromString()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick less than one item.');
+
+            Random::pick('abcdefghijklmnopqrstuvwxyz', -1);
+        }
+    }
+
+    public function testCantPickZeroElementFromCollection()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick less than one item.');
+
+            $collection = new Collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
+            Random::pick($collection, 0);
+        }
+    }
+
+    public function testCantPickLessThanZeroElementFromCollection()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('Can not pick less than one item.');
+
+            $collection = new Collection(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']);
+            Random::pick($collection, -1);
+        }
+    }
+
     public function testPickSingleFromArray()
     {
         $differentPick = false;


### PR DESCRIPTION
Fixes #11 

In this PR I have made Generator throw error on `pick()` when `$count` is less than 1 since it does not make since, same thing when `$count` is greater than `$values` length.