### PR TITLE
Fix: Do not attempt to return something from methods that do not return anything

### DIFF
--- a/tests/Assertions.php
+++ b/tests/Assertions.php
@@ -4,10 +4,12 @@ namespace Tests;
 
 trait Assertions
 {
-    protected function assertRegExpCustom($expression, $string, $message = '')
+    protected function assertRegExpCustom($expression, $string, $message = ''): void
     {
         if (method_exists($this, 'assertMatchesRegularExpression')) {
-            return $this->assertMatchesRegularExpression($expression, $string, $message);
+            $this->assertMatchesRegularExpression($expression, $string, $message);
+
+            return;
         }
 
         $this->assertRegExp($expression, $string, $message);


### PR DESCRIPTION
This pull request

- [x] stops attempting to return something from methods that do not return anything