### PR TITLE
Enhancement: Use `--strict` option when validating `composer.json` and `composer.lock`

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Validate composer.json and composer.lock
-        run: composer validate
+        run: composer validate --strict
 
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader


### PR DESCRIPTION
This pull request

- [x] uses the `--strict` option when validating `composer.json` and `composer.lock`

💁‍♂️ For reference, see https://getcomposer.org/doc/03-cli.md#validate.