### PR TITLE
Enhancement: Simplify `dashed` return

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -168,7 +168,7 @@ class Generator
     }
 
     /**
-     * Generate a random string of $length with lowercase and uppercase letters, and numbers, divided by $divider.
+     * Generate a random string of $length with lowercase and uppercase letters, and numbers, divided by $delimiter.
      * This is suitable for use as a long random password that is easy to read and type.
      *
      * @param  int     $length

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -180,7 +180,7 @@ class Generator
     {
         $string = $this->string($length, true, true, true, false, true);
 
-        return implode($delimiter, str_split($string, $chunkLength));
+        return wordwrap($string, $chunkLength, $delimiter, true);
     }
 
     /**


### PR DESCRIPTION
Minor refactor uses one function `wordwrap` instead of two for the generation of `dashed`, works with all PHP versions supported by Random. Also fixes typo of `$divider` to `$delimiter` in the comment block.