### PR TITLE
Enhancement: Include $lower attribute for `dashed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $token = Random::token(int $length = 32): string;
 $password = Random::password(int $length = 16, bool $requireAll = false): string;
 
 // Random alphanumeric token string with chunks separated by dashes, making it easy to read and type.
-$password = Random::dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5): string;
+$password = Random::dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5, bool $lower = true): string;
 ```
 
 To limit the characters available in any of the types (i.e. lower, upper, numbers, or symbols),

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -168,17 +168,18 @@ class Generator
     }
 
     /**
-     * Generate a random string of $length with lowercase and uppercase letters, and numbers, divided by $delimiter.
+     * Generate a random alphanumeric string of $length divided by $delimiter.
      * This is suitable for use as a long random password that is easy to read and type.
      *
      * @param  int     $length
      * @param  string  $delimiter
      * @param  int     $chunkLength = 5
+     * @param  bool    $lower
      * @return string
      */
-    public function dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5): string
+    public function dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5, bool $lower = true): string
     {
-        $string = $this->string($length, true, true, true, false, true);
+        $string = $this->string($length, $lower, true, true, false, true);
 
         return wordwrap($string, $chunkLength, $delimiter, true);
     }


### PR DESCRIPTION
By including `$lower` in the attributes for `dashed` it allows for the use cases of generating gift card codes or serial numbers (generally uppercase only) in a more efficient way than using `strtoupper` afterward.