### PR TITLE
Fix: Adjust `testUnexpectedSymbolsInput` for unfiltered symbols

### DIFF
--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -329,7 +329,7 @@ class StringTest extends TestCase
 
     public function testUnexpectedSymbolsInput()
     {
-        $generator = Random::useSymbols([2, 3, 4, 'F', 'a', '#', 88, '!', '9']);
+        $generator = Random::useSymbols([2, 3, 4, 'F', 'a', '#', '!', '9']);
 
         for ($i = 0; $i < 100; $i++) {
             $string = $generator->string(
@@ -341,10 +341,7 @@ class StringTest extends TestCase
                 $requireAll = false
             );
 
-            $this->assertRegExpCustom('/[#!]/', $string);
-            $this->assertRegExpCustom('/[^A-Z]/', $string);
-            $this->assertRegExpCustom('/[^a-f]/', $string);
-            $this->assertRegExpCustom('/[^1-9]/', $string);
+            $this->assertRegExpCustom('/^[2-4Fa#!9]+$/', $string);
         }
     }
 }


### PR DESCRIPTION
The filtering of provided symbols to `useSymbols` was removed with commit [914f0da](https://github.com/valorin/random/commit/914f0dafc7ea5f68bc2fe78e8cb444cc90a64c5c) and `testUnexpectedSymbolsInput` needed to be updated to reflect that in order to prevent random cases of failed tests.

Since a symbol can be any character now after that commit, the test was updated to confirm only symbols from the provided character set are used.

This begs the question though if `useSymbols` should still at least filter out alphanumeric characters since they are already covered by the other methods `useLower`, `useUpper`, and `useNumbers`?