### PR TITLE
Rename `dashed` $lower to $mixedCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $token = Random::token(int $length = 32): string;
 $password = Random::password(int $length = 16, bool $requireAll = false): string;
 
 // Random alphanumeric token string with chunks separated by dashes, making it easy to read and type.
-$password = Random::dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5, bool $lower = true): string;
+$password = Random::dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5, bool $mixedCase = true): string;
 ```
 
 To limit the characters available in any of the types (i.e. lower, upper, numbers, or symbols),

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -159,7 +159,7 @@ class Generator
      * Note, this doesn't guarantee that all the character sets will be included, you can use Random::string() for that.
      *
      * @param  int   $length
-     * @param  bool  $requireAll If true, at least one character from each set will be included.
+     * @param  bool  $requireAll  If true, at least one character from each set will be included.
      * @return string
      */
     public function password(int $length = 16, bool $requireAll = false): string
@@ -174,12 +174,12 @@ class Generator
      * @param  int     $length
      * @param  string  $delimiter
      * @param  int     $chunkLength = 5
-     * @param  bool    $lower
+     * @param  bool    $mixedCase  If true, lowercase letters will be included.
      * @return string
      */
-    public function dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5, bool $lower = true): string
+    public function dashed(int $length = 25, string $delimiter = '-', int $chunkLength = 5, bool $mixedCase = true): string
     {
-        $string = $this->string($length, $lower, true, true, false, true);
+        $string = $this->string($length, $mixedCase, true, true, false, true);
 
         return wordwrap($string, $chunkLength, $delimiter, true);
     }
@@ -272,7 +272,7 @@ class Generator
     }
 
     /**
-     * Use custom lower case character set for random string generation.
+     * Use custom lowercase character set for random string generation.
      *
      * @param array $characters
      * @return self
@@ -287,7 +287,7 @@ class Generator
     }
 
     /**
-     * Use custom upper case character set for random string generation.
+     * Use custom uppercase character set for random string generation.
      *
      * @param array $characters
      * @return self

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -218,10 +218,20 @@ class StringTest extends TestCase
     public function testDashed()
     {
         for ($i = 0; $i < 100; $i++) {
-            $string = Random::dashed($length = 25, $delimiter = '-');
+            $string = Random::dashed($length = 25, $delimiter = '-', $chunkLength = 5, $mixedCase = true);
 
             $this->assertIsString($string);
             $this->assertRegExpCustom('/^[a-zA-Z0-9]{5}\-[a-zA-Z0-9]{5}\-[a-zA-Z0-9]{5}\-[a-zA-Z0-9]{5}\-[a-zA-Z0-9]{5}$/', $string);
+        }
+    }
+
+    public function testDashedNoLowerCase()
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $string = Random::dashed($length = 25, $delimiter = '-', $chunkLength = 5, $mixedCase = false);
+
+            $this->assertIsString($string);
+            $this->assertRegExpCustom('/^[A-Z0-9]{5}\-[A-Z0-9]{5}\-[A-Z0-9]{5}\-[A-Z0-9]{5}\-[A-Z0-9]{5}$/', $string);
         }
     }
 


### PR DESCRIPTION
Improvement upon https://github.com/valorin/random/pull/16 for added clarity:

When `$mixedCase` for `dashed` is true both uppercase and lowercase letters are included, and when false lowercase letters are excluded. Also created a test to confirm this and made some minor comment adjustments.