### PR TITLE
Allow string as input for useSymbols

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -282,11 +282,15 @@ class Generator
     /**
      * Use custom lowercase character set for random string generation.
      *
-     * @param array $characters
+     * @param array|string $characters
      * @return self
      */
-    public function useLower(array $characters): self
+    public function useLower($characters): self
     {
+        $characters = is_array($characters)
+            ? $characters
+            : str_split($characters);
+
         $characters = array_filter($characters, 'ctype_lower');
 
         $this->lowerCharacters = $characters;
@@ -297,11 +301,15 @@ class Generator
     /**
      * Use custom uppercase character set for random string generation.
      *
-     * @param array $characters
+     * @param array|string $characters
      * @return self
      */
-    public function useUpper(array $characters): self
+    public function useUpper($characters): self
     {
+        $characters = is_array($characters)
+            ? $characters
+            : str_split($characters);
+
         $characters = array_filter($characters, 'ctype_upper');
 
         $this->upperCharacters = $characters;
@@ -312,11 +320,15 @@ class Generator
     /**
      * Use custom numbers for random string generation.
      *
-     * @param array $characters
+     * @param array|string $characters
      * @return self
      */
-    public function useNumbers(array $characters): self
+    public function useNumbers($characters): self
     {
+        $characters = is_array($characters)
+            ? $characters
+            : str_split($characters);
+
         $characters = array_filter($characters, function ($character) {
             return $character >= 0 && $character <= 9;
         });
@@ -332,8 +344,8 @@ class Generator
      * @param array|string $characters
      * @return self
      */
-    public function useSymbols(array|string $characters): self
-    {        
+    public function useSymbols($characters): self
+    {
         $this->symbolCharacters = is_array($characters)
             ? $characters
             : str_split($characters);

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -329,12 +329,14 @@ class Generator
     /**
      * Use custom symbol character set for random string generation.
      *
-     * @param array $characters
+     * @param array|string $characters
      * @return self
      */
-    public function useSymbols(array $characters): self
-    {
-        $this->symbolCharacters = $characters;
+    public function useSymbols(array|string $characters): self
+    {        
+        $this->symbolCharacters = is_array($characters)
+            ? $characters
+            : str_split($characters);
 
         return $this;
     }

--- a/src/Random.php
+++ b/src/Random.php
@@ -17,10 +17,10 @@ namespace Valorin\Random;
  * @method static array|\Illuminate\Support\Collection pick(array|\Illuminate\Support\Collection $values, int $count) Pick $count random items (or characters) from an array or Laravel Collection.
  * @method static array|string|\Illuminate\Support\Collection single(array|string|\Illuminate\Support\Collection $values) Picks a single item (or character) from an array, string, or Laravel Collection.
  * @method static array|string|\Illuminate\Support\Collection pickOne(array|string|\Illuminate\Support\Collection $values) Picks a single item (or character) from an array, string, or Laravel Collection.
- * @method static Generator useLower(array $characters) Use custom lower case character set for random string generation.
- * @method static Generator useUpper(array $characters) Use custom upper case character set for random string generation.
- * @method static Generator useNumbers(array $characters) Use custom number characters for random string generation.
- * @method static Generator useSymbols(array $characters) Use custom symbol character set for random string generation.
+ * @method static Generator useLower(array|string $characters) Use custom lower case character set for random string generation.
+ * @method static Generator useUpper(array|string $characters) Use custom upper case character set for random string generation.
+ * @method static Generator useNumbers(array|string $characters) Use custom number characters for random string generation.
+ * @method static Generator useSymbols(array|string $characters) Use custom symbol character set for random string generation.
  */
 class Random
 {

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -354,4 +354,76 @@ class StringTest extends TestCase
             $this->assertRegExpCustom('/^[2-4Fa#!9]+$/', $string);
         }
     }
+
+    public function testLowerInputFromString()
+    {
+        $generator = Random::useLower('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
+
+        for ($i = 0; $i < 100; $i++) {
+            $string = $generator->string(
+                $length = 32,
+                $lower = true,
+                $upper = false,
+                $numbers = false,
+                $symbols = false,
+                $requireAll = false
+            );
+
+            $this->assertRegExpCustom('/^[a-z]+$/', $string);
+        }
+    }
+
+    public function testUpperInputFromString()
+    {
+        $generator = Random::useUpper('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');
+
+        for ($i = 0; $i < 100; $i++) {
+            $string = $generator->string(
+                $length = 32,
+                $lower = false,
+                $upper = true,
+                $numbers = false,
+                $symbols = false,
+                $requireAll = false
+            );
+
+            $this->assertRegExpCustom('/^[A-Z]+$/', $string);
+        }
+    }
+
+    public function testNumbersInputFromString()
+    {
+        $generator = Random::useNumbers("02468");
+
+        for ($i = 0; $i < 100; $i++) {
+            $string = $generator->string(
+                $length = 32,
+                $lower = false,
+                $upper = false,
+                $numbers = true,
+                $symbols = false,
+                $requireAll = false
+            );
+
+            $this->assertRegExpCustom('/[0|2|4|6|8]/', $string);
+        }
+    }
+
+    public function testSymbolsInputFromString()
+    {
+        $generator = Random::useSymbols('abcdefghijklmnopqrstuvwxyz12345^&*()');
+
+        for ($i = 0; $i < 100; $i++) {
+            $string = $generator->string(
+                $length = 32,
+                $lower = false,
+                $upper = false,
+                $numbers = false,
+                $symbols = true,
+                $requireAll = false
+            );
+
+            $this->assertRegExpCustom('/^[a-z12345^&*()]+$/', $string);
+        }
+    }
 }


### PR DESCRIPTION
This allows defining symbols list as a string instead of an array. Makes for better DX.

Example:
```php
Random::useSymbols("A1B2C3D4")->string();
```